### PR TITLE
setup redis cluster (fix #6)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,3 @@
 make .virtualenv
 . .virtualenv/bin/activate
-export 'ANSIBLE_PLAYBOOK=provision_ubuntu_vm.yml'
+export 'ANSIBLE_PLAYBOOK=provision_ubuntu_vm'

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ requirements: .virtualenv
 		&& pip3 install -r requirements.txt \
 		&& ansible-galaxy install -r galaxy_requirements.yml
 
+images:
+	@packer build -var playbook=provision_redis_image images.json
+
 ubuntu:
 	@vagrant up --provision
 
@@ -14,4 +17,4 @@ clean:
 	@-vagrant destroy -f
 	@-rm -fr .virtualenv /tmp/.galaxy_roles
 
-.PHONY: requirements ubuntu clean
+.PHONY: requirements images ubuntu clean

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 ### reqs
 
 - Direnv
+- Docker
+- Packer
 - Vagrant
 - Virtualbox
 
@@ -10,5 +12,5 @@
 
 ```bash
 direnv allow
-make requirements ubuntu
+make requirements images ubuntu
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ ANSIBLE_EXTRA_VARS   = {
     'provision_user_name'    => ENV['USER'],
     'provision_user_ssh_key' => File.read("#{Dir.home}/.ssh/id_rsa.pub"),
 }
-ANSIBLE_PLAYBOOK     = ENV.fetch('ANSIBLE_PLAYBOOK', '') + '.yml'
+ANSIBLE_PLAYBOOK     = ENV.fetch('ANSIBLE_PLAYBOOK', '')
 VM_APPDATA_DISK_FILE = './disks/hdx_appdata.vdi'
 VM_APPDATA_DISK_SIZE = 2 * 1024
 VM_GUI_ENABLED       = ENV.fetch('VM_GUI_ENABLED', '') != ''
@@ -16,7 +16,7 @@ def ansible_provision(vm)
         ansible.groups = {
             "test_hosts" => ["ubuntu"]
         }
-        ansible.playbook = "playbooks/" + ANSIBLE_PLAYBOOK
+        ansible.playbook = "playbooks/" + ANSIBLE_PLAYBOOK + ".yml"
         ansible.raw_arguments = ["--extra-vars", ANSIBLE_EXTRA_VARS.to_json, "-vv", "--diff"]
     end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,10 +5,10 @@ ANSIBLE_EXTRA_VARS   = {
     'provision_user_name'    => ENV['USER'],
     'provision_user_ssh_key' => File.read("#{Dir.home}/.ssh/id_rsa.pub"),
 }
-ANSIBLE_PLAYBOOK     = ENV['ANSIBLE_PLAYBOOK'] || ''
-VM_APPDATA_DISK_FILE = "./disks/hdx_appdata.vdi"
+ANSIBLE_PLAYBOOK     = ENV.fetch('ANSIBLE_PLAYBOOK', '') + '.yml'
+VM_APPDATA_DISK_FILE = './disks/hdx_appdata.vdi'
 VM_APPDATA_DISK_SIZE = 2 * 1024
-VM_GUI_ENABLED       = (ENV['VM_GUI_ENABLED'] || "") != ""
+VM_GUI_ENABLED       = ENV.fetch('VM_GUI_ENABLED', '') != ''
 
 
 def ansible_provision(vm)

--- a/galaxy_requirements.yml
+++ b/galaxy_requirements.yml
@@ -4,3 +4,5 @@
   version: v1.2.1
 - src: geerlingguy.docker
   version: 2.5.3
+- src: davidwittman.redis
+  version: 1.2.7

--- a/images.json
+++ b/images.json
@@ -1,0 +1,41 @@
+{
+
+    "variables": {
+        "extra_args_json": "{}",
+        "playbook": null
+    },
+
+    "builders": [{
+        "type": "docker",
+        "image": "ubuntu:bionic",
+        "commit": true,
+        "privileged": false,
+        "changes": [
+            "CMD tail -F /dev/null"
+        ],
+        "run_command": [
+            "-d", "-i", "-t", "--name", "default", "{{.Image}}", "/bin/bash"
+        ]
+    }],
+
+    "provisioners": [{
+        "type": "ansible",
+        "groups": "ubuntu",
+        "ansible_env_vars": [
+            "PYTHONUNBUFFERED=1"
+        ],
+        "extra_arguments": [
+            "-v",
+            "--diff",
+            "--extra-vars", "{{ user `extra_args_json` }}"
+        ],
+        "playbook_file": "{{template_dir}}/playbooks/{{ user `playbook` }}.yml"
+    }],
+
+    "post-processors": [[{
+            "type": "docker-tag",
+            "repository": "127.0.0.1:5000/devopstest/{{ user `playbook` }}",
+            "tag": "latest"
+    }]]
+
+}

--- a/playbooks/provision_redis_image.yml
+++ b/playbooks/provision_redis_image.yml
@@ -1,0 +1,12 @@
+- hosts: ubuntu
+  gather_facts: no
+
+  pre_tasks:
+    - raw: >-
+        apt update -qq && apt install -y python3
+    - setup:
+
+  roles:
+    - role: davidwittman.redis
+      vars:
+        - redis_bind: 127.0.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+ansible==2.9.1
 molecule==2.22
 wheel==0.33.6


### PR DESCRIPTION
INCOMPLETE

Obstacles:
- role `davidwittman.redis` fails on docker (during a kernel config change attempt),

```
    docker: TASK [davidwittman.redis : enable overcommit in sysctl] ************************
    docker: fatal: [default]: FAILED! => {"changed": false, "msg": "Failed to reload sysctl: sysctl: setting key \"vm.overcommit_memory\": Read-only file system\n"}
    docker:
```

Still Todo:
1. fix the above,
1. add config method for the container image (env vars maybe),
1. the ubuntu vm provisioning playbook needs next play which starts a set of containers (using the image created with packer) and configures them appropriately (using pt. 2 method)